### PR TITLE
Distinguish properly between qid '1' and qid '13' in device manager

### DIFF
--- a/qubesdbus/device_manager.py
+++ b/qubesdbus/device_manager.py
@@ -99,7 +99,7 @@ class DeviceManager(qubesdbus.service.ObjectManager):
 
         vm_path_prefix = os.path.join(SERVICE_PATH, dev_class, str(vm.qid))
         known_devices = [
-            p for p in self.devices if p.startswith(vm_path_prefix)
+            p for p in self.devices if p.startswith(vm_path_prefix + '/')
         ]
 
         # remove non existing own devices


### PR DESCRIPTION
There was an error in determining which devices are in a given VM,
caused by incorrectly checking if a path started with a VM's qid.

fixes QubesOS/qubes-issues#4078